### PR TITLE
Fix deprecated usage of symfony yaml parse()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 sudo: false
 php:
-  - 5.4
   - 5.5
   - 5.6
 

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,9 @@
     "name": "gong023/ayaml",
     "description": "utility to convert yaml to array",
     "require": {
-        "symfony/yaml": "3.1.2",
-        "nesbot/Carbon": "*",
+        "php": ">=5.5",
+        "symfony/yaml": "3.1.*",
+        "nesbot/carbon": "~1",
         "gong023/retry": "^0.2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "gong023/ayaml",
     "description": "utility to convert yaml to array",
     "require": {
-        "symfony/yaml": "~2.0",
+        "symfony/yaml": "3.1.2",
         "nesbot/Carbon": "*",
         "gong023/retry": "^0.2.0"
     },

--- a/spec/unit/Fixture/YamlData.spec.php
+++ b/spec/unit/Fixture/YamlData.spec.php
@@ -24,7 +24,7 @@ describe('\\Ayaml\\Fixture\\YamlData', function() {
     context('getSchema', function() {
         context('normal case', function() {
             beforeEach(function() {
-                $data = SymfonyYaml::parse(__DIR__ . '/../../SampleYaml/user.yml', true);
+                $data = SymfonyYaml::parse(file_get_contents(__DIR__ . '/../../SampleYaml/user.yml', SymfonyYaml::PARSE_EXCEPTION_ON_INVALID_TYPE));
                 $this->yamlData = new YamlData($data);
             });
 
@@ -60,7 +60,7 @@ describe('\\Ayaml\\Fixture\\YamlData', function() {
 
             it('should throw when schema not found', function() {
                 expect(function() {
-                    $data = SymfonyYaml::parse(__DIR__ . '/../../SampleYaml/user.yml', true);
+                    $data = SymfonyYaml::parse(file_get_contents(__DIR__ . '/../../SampleYaml/user.yml', SymfonyYaml::PARSE_EXCEPTION_ON_INVALID_TYPE));
                     $yamlData = new YamlData($data);
                     $yamlData->getSchema('no existing schema');
                 })->to->throw('\\Ayaml\\Fixture\\AyamlSchemaNotFoundException');

--- a/src/Fixture/YamlData.php
+++ b/src/Fixture/YamlData.php
@@ -82,7 +82,7 @@ class YamlData
                     throw new AyamlFixtureFileNotFoundException('base path: ' . $basePath . ' / file name:' . $fileName);
                 }
 
-                return SymfonyYaml::parse(file_get_contents($filePath), true);
+                return SymfonyYaml::parse(file_get_contents($filePath), SymfonyYaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
             });
 
         return new self($rawData);

--- a/src/Fixture/YamlData.php
+++ b/src/Fixture/YamlData.php
@@ -82,7 +82,7 @@ class YamlData
                     throw new AyamlFixtureFileNotFoundException('base path: ' . $basePath . ' / file name:' . $fileName);
                 }
 
-                return SymfonyYaml::parse($filePath, true);
+                return SymfonyYaml::parse(file_get_contents($filePath), true);
             });
 
         return new self($rawData);


### PR DESCRIPTION
`Symfony\Component\Yaml` says:

> the ability to pass file names to the Yaml::parse method is deprecated
> since version 2.2 and will be removed in 3.0. Pass the YAML contents of
> the file instead.
> https://github.com/symfony/symfony/blob/4ef4c2c1e1b6f08aef734a64438ec2505711f283/src/Symfony/Component/Yaml/Yaml.php#L58

Note:
Also the latest version of `Symfony\Yaml` says:

> Passing a boolean flag to toggle exception handling is deprecated
> since version 3.1 and will be removed in 4.0.
> https://github.com/symfony/symfony/blob/194dcf3b5d49cf14486b198a179e05c9e1b4ea15/src/Symfony/Component/Yaml/Yaml.php#L52
