### PR TITLE
Use gong023/retry 0.2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "php": ">=5.5",
         "symfony/yaml": "^5.3.6",
         "nesbot/carbon": "^2.57",
-        "gong023/retry": "^0.2.0"
+        "gong023/retry": "^0.2.1"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",


### PR DESCRIPTION
Resolves the below error for PHP 8.2
```
Creation of dynamic property Retry\Retry::$container is deprecated
```

Ref: https://github.com/gong023/retry/pull/2