### PR TITLE
PHP 8.2 - Dynamic property fixes for Calculator

### DIFF
--- a/src/Sequence/Calculator.php
+++ b/src/Sequence/Calculator.php
@@ -11,6 +11,18 @@ use Ayaml\ContainerCollection;
  */
 abstract class Calculator
 {
+    /** @var ContainerCollection */
+    protected $containerCollection;
+
+    /** @var string */
+    protected $targetKey;
+
+    /** @var mixed */
+    protected $criteria;
+
+    /** @var mixed */
+    protected $end;
+
     /**
      * @param ContainerCollection $containerCollection
      * @param string              $targetKey


### PR DESCRIPTION
```
Deprecated: Creation of dynamic property Ayaml\Sequence\Calculator\Numeric\Incrementer::$criteria is deprecated in /.../vendor/gong023/ayaml/src/Sequence/Calculator.php on line 24
```